### PR TITLE
ci: add GitHub Actions workflows for CI and commit linting

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,80 @@
+# Commitlint configuration for conventional commits
+# Based on: https://www.conventionalcommits.org/
+
+extends:
+  - '@commitlint/config-conventional'
+
+rules:
+  # Type enum - allowed commit types
+  type-enum:
+    - 2  # Level: error
+    - always
+    - # Allowed types:
+      - feat      # New feature
+      - fix       # Bug fix
+      - docs      # Documentation only changes
+      - style     # Code style changes (formatting, missing semi-colons, etc)
+      - refactor  # Code refactoring (neither fixes a bug nor adds a feature)
+      - perf      # Performance improvements
+      - test      # Adding or updating tests
+      - build     # Changes to build system or dependencies
+      - ci        # CI/CD configuration changes
+      - chore     # Other changes that don't modify src or test files
+      - revert    # Revert a previous commit
+
+  # Type case should be lowercase
+  type-case:
+    - 2
+    - always
+    - lower-case
+
+  # Type must not be empty
+  type-empty:
+    - 2
+    - never
+
+  # Scope case should be lowercase
+  scope-case:
+    - 2
+    - always
+    - lower-case
+
+  # Subject must not be empty
+  subject-empty:
+    - 2
+    - never
+
+  # Subject must not end with a period
+  subject-full-stop:
+    - 2
+    - never
+    - '.'
+
+  # Disable subject-case to allow uppercase abbreviations (PR, API, CLI, etc.)
+  subject-case:
+    - 0
+
+  # Header (first line) max length
+  header-max-length:
+    - 2
+    - always
+    - 72
+
+  # Body should have a blank line before it
+  body-leading-blank:
+    - 1  # Warning level
+    - always
+
+  # Footer should have a blank line before it
+  footer-leading-blank:
+    - 1  # Warning level
+    - always
+
+  # Body max line length
+  body-max-line-length:
+    - 1  # Warning level
+    - always
+    - 100
+
+# Help URL shown in error messages
+helpUrl: 'https://www.conventionalcommits.org/'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        platform: [x64, x86]
+        configuration: [Debug, Release]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore CodingWithCalvin.VSToolbox.sln
+
+      - name: Build
+        run: dotnet build CodingWithCalvin.VSToolbox.sln --configuration ${{ matrix.configuration }} -p:Platform=${{ matrix.platform }} --no-restore
+
+      - name: Test
+        run: dotnet test CodingWithCalvin.VSToolbox.sln --configuration ${{ matrix.configuration }} -p:Platform=${{ matrix.platform }} --no-build --verbosity normal

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,59 @@
+name: Lint Commit Messages
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint-pr-title:
+    name: Lint PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install commitlint
+        run: |
+          npm install --save-dev @commitlint/cli@18.4.3 @commitlint/config-conventional@18.4.3
+
+      - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "Validating PR title: $PR_TITLE"
+          echo "$PR_TITLE" | npx commitlint --verbose
+
+  commitlint:
+    name: Lint Commit Messages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for all branches and tags
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install commitlint
+        run: |
+          npm install --save-dev @commitlint/cli@18.4.3 @commitlint/config-conventional@18.4.3
+
+      - name: Validate PR commits
+        run: |
+          # Get the base branch (usually main)
+          BASE_SHA=$(git merge-base origin/${{ github.base_ref }} HEAD)
+
+          # Lint all commits in the PR
+          npx commitlint --from $BASE_SHA --to HEAD --verbose


### PR DESCRIPTION
## Summary
- Add CI workflow that builds and tests on push to main and PRs
  - Matrix build: x64/x86 × Debug/Release
  - Uses .NET 10
- Add commit-lint workflow to enforce conventional commits
  - Validates PR titles
  - Validates all commits in a PR
- Add `.commitlintrc.yml` configuration