### PR TITLE
ci: add preview changelog and contributors workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - '*.sln'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**'
+      - '*.sln'
+      - '.github/workflows/ci.yml'
 
 jobs:
   build:

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,76 @@
+name: Update Contributors
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run daily at midnight UTC
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  contributors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.CONTRIBUTORS_TOKEN }}
+
+      - name: Update contributors
+        env:
+          GH_TOKEN: ${{ secrets.CONTRIBUTORS_TOKEN }}
+        run: |
+          # Fetch code contributors (exclude bots)
+          code_contributors=$(gh api repos/${{ github.repository }}/contributors --paginate --jq '.[] | select(.type != "Bot") | select(.login | test("\\[bot\\]$") | not) | .login')
+
+          # Fetch closed issues and check if they were closed by a PR
+          issue_authors=""
+          closed_issues=$(gh api repos/${{ github.repository }}/issues --paginate -q '.[] | select(.state == "closed") | select(.pull_request == null) | {number, login: .user.login}')
+
+          for row in $(echo "$closed_issues" | jq -c '.'); do
+            issue_num=$(echo "$row" | jq -r '.number')
+            login=$(echo "$row" | jq -r '.login')
+
+            # Check timeline for closed event with commit (meaning closed by PR)
+            closed_by_pr=$(gh api repos/${{ github.repository }}/issues/$issue_num/timeline --paginate -q '.[] | select(.event == "closed") | select(.commit_id != null) | .commit_id' | head -1)
+
+            if [[ -n "$closed_by_pr" ]]; then
+              issue_authors="$issue_authors$login"$'\n'
+            fi
+          done
+          issue_authors=$(echo "$issue_authors" | sort -u)
+
+          # Combine and deduplicate
+          all_contributors=$(echo -e "$code_contributors\n$issue_authors" | sort -u | grep -v '^$')
+
+          # Build markdown for each contributor
+          contributor_md=""
+          for login in $all_contributors; do
+            # Skip bots
+            if [[ "$login" == *"[bot]" ]]; then
+              continue
+            fi
+
+            # Get user info
+            user_info=$(gh api users/$login --jq '{avatar_url, html_url}')
+            avatar=$(echo "$user_info" | jq -r '.avatar_url')
+            url=$(echo "$user_info" | jq -r '.html_url')
+
+            contributor_md="$contributor_md[![$login](${avatar}&s=64)]($url) "
+          done
+
+          # Build the contributors section
+          contrib_section="<!-- readme: contributors -start -->
+          $contributor_md
+          <!-- readme: contributors -end -->"
+
+          # Update README between the markers
+          awk -v contrib="$contrib_section" '
+            /<!-- readme: contributors -start -->/{found=1; print contrib; next}
+            /<!-- readme: contributors -end -->/{found=0; next}
+            !found{print}
+          ' README.md > README.tmp && mv README.tmp README.md
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git diff --staged --quiet || (git commit -m "docs: update contributors [skip ci]" && git push)

--- a/.github/workflows/preview-changelog.yml
+++ b/.github/workflows/preview-changelog.yml
@@ -1,0 +1,29 @@
+name: Preview Changelog
+
+run-name: Preview release notes for next release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  generate:
+    name: Generate
+    uses: CodingWithCalvin/.github/.github/workflows/generate-changelog.yml@main
+    secrets: inherit
+
+  preview:
+    name: Display Preview
+    runs-on: ubuntu-latest
+    needs: generate
+
+    steps:
+    - name: Display changelog preview
+      run: |
+        echo "=========================================="
+        echo "CHANGELOG PREVIEW"
+        echo "=========================================="
+        echo ""
+        echo "## What's New in v<VERSION>"
+        echo ""
+        echo "${{ needs.generate.outputs.changelog }}"
+      shell: bash

--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ Contributions are welcome! Feel free to:
 4. 📤 Push to the branch (`git push origin feature/amazing-feature`)
 5. 🎉 Open a Pull Request
 
+## 👥 Contributors
+
+<!-- readme: contributors -start -->
+<!-- readme: contributors -end -->
+
 ---
 
 ## 📄 License


### PR DESCRIPTION
## Summary
- Add preview-changelog workflow for manual changelog preview
- Add nightly contributors workflow to update README
  - Includes both code contributors and issue authors
  - Uses markdown formatting for avatars
- Add contributors section to README with markers

## Required Secrets
- `CONTRIBUTORS_TOKEN` - PAT with repo write access for committing README updates