### PR TITLE
fix(ci): add state=closed param to issues API call

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -22,7 +22,7 @@ jobs:
 
           # Fetch closed issues and check if they were closed by a merged PR
           issue_authors=""
-          closed_issues=$(gh api repos/${{ github.repository }}/issues --paginate -q '.[] | select(.state == "closed") | select(.pull_request == null) | {number, login: .user.login}')
+          closed_issues=$(gh api "repos/${{ github.repository }}/issues?state=closed" --paginate -q '.[] | select(.pull_request == null) | {number, login: .user.login}')
 
           for row in $(echo "$closed_issues" | jq -c '.'); do
             issue_num=$(echo "$row" | jq -r '.number')


### PR DESCRIPTION
## Summary
The GitHub Issues API defaults to returning only **open** issues. The workflow wasn't finding any closed issues to check for PR references.

Added `?state=closed` to the API call to fetch closed issues.

## Root Cause
```bash
# Without state param - returns nothing (only open issues)
gh api repos/CodingWithCalvin/VSToolbox/issues -q '.[] | select(.state == "closed")'

# With state=closed - returns closed issues
gh api "repos/CodingWithCalvin/VSToolbox/issues?state=closed" -q '.[]'
```