### PR TITLE
feat: add channel type badge to VS instance list

### DIFF
--- a/src/CodingWithCalvin.VSToolbox.Core/Models/LaunchableInstance.cs
+++ b/src/CodingWithCalvin.VSToolbox.Core/Models/LaunchableInstance.cs
@@ -15,6 +15,7 @@ public sealed class LaunchableInstance
     public string BuildNumber => Instance.BuildNumber;
     public string InstallationPath => Instance.InstallationPath;
     public bool IsPrerelease => Instance.IsPrerelease;
+    public string ChannelType => Instance.ChannelType;
     public string? IconPath => Instance.IconPath;
     public bool CanLaunch => Instance.CanLaunch;
 

--- a/src/CodingWithCalvin.VSToolbox.Core/Models/VisualStudioInstance.cs
+++ b/src/CodingWithCalvin.VSToolbox.Core/Models/VisualStudioInstance.cs
@@ -21,6 +21,26 @@ public sealed class VisualStudioInstance
 
     public string BuildNumber => InstallationVersion;
 
+    public string ChannelType => ParseChannelType(ChannelId);
+
+    private static string ParseChannelType(string channelId)
+    {
+        // ChannelId format: VisualStudio.{majorVersion}.{channel}
+        // e.g., VisualStudio.17.Release, VisualStudio.17.Preview, VisualStudio.17.Canary
+        var parts = channelId.Split('.');
+        if (parts.Length < 3)
+            return "Unknown";
+
+        return parts[^1] switch
+        {
+            "Release" => "Stable",
+            "Preview" => "Preview",
+            "Canary" => "Canary",
+            "IntPreview" => "Internal Preview",
+            _ => parts[^1]
+        };
+    }
+
     public bool CanLaunch => !string.IsNullOrEmpty(ProductPath) &&
         ProductPath.EndsWith("devenv.exe", StringComparison.OrdinalIgnoreCase);
 

--- a/src/CodingWithCalvin.VSToolbox/App.xaml
+++ b/src/CodingWithCalvin.VSToolbox/App.xaml
@@ -19,6 +19,7 @@
             <converters:FilePathToImageConverter x:Key="FilePathToImageConverter"/>
             <converters:CountToVisibilityConverter x:Key="CountToVisibilityConverter"/>
             <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+            <converters:ChannelTypeToBrushConverter x:Key="ChannelTypeToBrushConverter"/>
 
             <x:Double x:Key="AppFontSize">14</x:Double>
 

--- a/src/CodingWithCalvin.VSToolbox/Converters/ChannelTypeToBrushConverter.cs
+++ b/src/CodingWithCalvin.VSToolbox/Converters/ChannelTypeToBrushConverter.cs
@@ -1,0 +1,27 @@
+using Microsoft.UI;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media;
+
+namespace CodingWithCalvin.VSToolbox.Converters;
+
+public sealed class ChannelTypeToBrushConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, string language)
+    {
+        var channelType = value as string ?? "Unknown";
+
+        return channelType switch
+        {
+            "Stable" => new SolidColorBrush(ColorHelper.FromArgb(255, 34, 197, 94)),    // Green
+            "Preview" => new SolidColorBrush(ColorHelper.FromArgb(255, 168, 85, 247)),  // Purple
+            "Canary" => new SolidColorBrush(ColorHelper.FromArgb(255, 251, 191, 36)),   // Amber/Yellow
+            "Internal Preview" => new SolidColorBrush(ColorHelper.FromArgb(255, 239, 68, 68)), // Red
+            _ => new SolidColorBrush(ColorHelper.FromArgb(255, 107, 114, 128))          // Gray
+        };
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/CodingWithCalvin.VSToolbox/Views/MainPage.xaml
+++ b/src/CodingWithCalvin.VSToolbox/Views/MainPage.xaml
@@ -84,34 +84,37 @@
                                     TextTrimming="CharacterEllipsis"/>
                             </StackPanel>
 
-                            <!-- Prerelease Badge -->
+                            <!-- Channel Type Badge -->
                             <Border
                                 Grid.Column="2"
-                                Visibility="{x:Bind IsPrerelease}"
-                                Background="{ThemeResource SystemAccentColorDark1}"
                                 CornerRadius="4"
                                 Padding="8,4"
-                                VerticalAlignment="Center">
+                                VerticalAlignment="Center"
+                                Background="{x:Bind ChannelType, Converter={StaticResource ChannelTypeToBrushConverter}}">
                                 <TextBlock
-                                    Text="Preview"
+                                    Text="{x:Bind ChannelType}"
                                     FontSize="10"
-                                    Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"/>
+                                    FontWeight="SemiBold"
+                                    Foreground="White"/>
                             </Border>
 
                             <!-- Action Buttons -->
                             <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
-                                <Button
-                                    Click="OnLaunchClick"
-                                    ToolTipService.ToolTip="Launch"
-                                    Visibility="{x:Bind CanLaunch, Converter={StaticResource BoolToVisibilityConverter}}"
-                                    Padding="8"
-                                    Background="Transparent"
-                                    BorderThickness="0"
-                                    Opacity="0.6"
-                                    PointerEntered="OnButtonPointerEntered"
-                                    PointerExited="OnButtonPointerExited">
-                                    <SymbolIcon Symbol="Play" Foreground="#22C55E"/>
-                                </Button>
+                                <!-- Fixed-width container to maintain alignment when Play button is hidden -->
+                                <Border Width="40">
+                                    <Button
+                                        Click="OnLaunchClick"
+                                        ToolTipService.ToolTip="Launch"
+                                        Visibility="{x:Bind CanLaunch, Converter={StaticResource BoolToVisibilityConverter}}"
+                                        Padding="8"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        Opacity="0.6"
+                                        PointerEntered="OnButtonPointerEntered"
+                                        PointerExited="OnButtonPointerExited">
+                                        <SymbolIcon Symbol="Play" Foreground="#22C55E"/>
+                                    </Button>
+                                </Border>
                                 <Button
                                     ToolTipService.ToolTip="Options"
                                     Padding="8"


### PR DESCRIPTION
## Summary
- Add colored badge displaying channel type (Stable, Preview, Canary, Internal Preview) for each VS installation
- Parse ChannelId from vswhere to determine build channel
- Color-coded badges: green (Stable), purple (Preview), amber (Canary), red (Internal Preview), gray (Unknown)
- Fixed button alignment issue when Play button is hidden for Build Tools installations

Closes #3

## Test plan
- [ ] Verify Stable installations show green badge
- [ ] Verify Preview installations show purple badge
- [ ] Verify Canary installations show amber badge
- [ ] Verify action buttons remain aligned when Play button is hidden