### PR TITLE
fix(ci): pass LINKEDIN_CLIENT_ID to reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,3 +190,4 @@ jobs:
         Check out the release notes here: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
     secrets:
       LINKEDIN_ACCESS_TOKEN: ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
+      LINKEDIN_CLIENT_ID: ${{ secrets.LINKEDIN_CLIENT_ID }}


### PR DESCRIPTION
Pass the organization-level LINKEDIN_CLIENT_ID secret to the linkedin-post reusable workflow.