### PR TITLE
docs: add community templates and guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "fix: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the form below.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of the bug.
+      placeholder: Describe the bug...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: Describe what you expected...
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+      placeholder: Describe what actually happened...
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Windows Version
+      description: Which version of Windows are you using?
+      placeholder: "e.g., Windows 11 23H2"
+    validations:
+      required: true
+
+  - type: input
+    id: vs-versions
+    attributes:
+      label: Visual Studio Versions
+      description: Which Visual Studio versions are installed?
+      placeholder: "e.g., VS 2022 17.8, VS 2019 16.11"
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots, or logs about the problem.
+      placeholder: Any additional information...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please fill out the form below.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: Is your feature request related to a problem? Please describe.
+      placeholder: "I'm always frustrated when..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+      placeholder: Describe your proposed feature...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions or features you've considered.
+      placeholder: Other approaches you've thought about...
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context, mockups, or screenshots about the feature request.
+      placeholder: Any additional information...
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Description
+
+<!-- Briefly describe the changes in this PR -->
+
+## Type of Change
+
+<!-- Mark the relevant option with an "x" -->
+
+- [ ] `feat` - New feature
+- [ ] `fix` - Bug fix
+- [ ] `docs` - Documentation only
+- [ ] `refactor` - Code change that neither fixes a bug nor adds a feature
+- [ ] `test` - Adding or updating tests
+- [ ] `chore` - Maintenance tasks
+- [ ] `ci` - CI/CD changes
+
+## Related Issues
+
+<!-- Link any related issues using "Closes #123" or "Fixes #123" -->
+
+## Checklist
+
+- [ ] My code follows the project's code style
+- [ ] I have tested my changes locally
+- [ ] I have updated documentation if needed
+- [ ] My commits follow the conventional commit format
+- [ ] This PR has a descriptive title using conventional commit format
+
+## Screenshots (if applicable)
+
+<!-- Add screenshots to help explain your changes -->
+
+## Additional Notes
+
+<!-- Any additional information reviewers should know -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,138 @@
+# Contributor Covenant Code of Conduct
+
+## Our Core Value: People FIRST
+
+Above all else, this project puts **people first**. We believe that the humans behind the code matter more than the code itself. Every interaction, contribution, and decision should reflect our commitment to treating people with dignity, respect, and kindness.
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Putting people first in all interactions
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,140 @@
+# Contributing to VSToolbox
+
+Thank you for your interest in contributing to VSToolbox! This document provides guidelines and instructions for contributing.
+
+## Development Environment Setup
+
+### Prerequisites
+
+- Windows 10/11
+- [.NET 10.0 SDK](https://dotnet.microsoft.com/download) (Preview)
+- [Visual Studio 2022](https://visualstudio.microsoft.com/) with the following workloads:
+  - .NET Desktop Development
+  - Windows App SDK C# Templates
+- Git
+
+### Getting Started
+
+1. Fork the repository on GitHub
+2. Clone your fork locally:
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/VSToolbox.git
+   cd VSToolbox
+   ```
+3. Add the upstream remote:
+   ```bash
+   git remote add upstream https://github.com/CodingWithCalvin/VSToolbox.git
+   ```
+4. Build the project:
+   ```bash
+   dotnet build src/CodingWithCalvin.VSToolbox/CodingWithCalvin.VSToolbox.csproj
+   ```
+5. Run the application:
+   ```bash
+   dotnet run --project src/CodingWithCalvin.VSToolbox/CodingWithCalvin.VSToolbox.csproj
+   ```
+
+## Code Style and Conventions
+
+### General Guidelines
+
+- Follow standard C# coding conventions
+- Use meaningful variable and method names
+- Keep methods focused and concise
+- All UI must use WinUI 3/XAML with Fluent Design
+- Use theme resources for colors (no hardcoded colors except brand purple `#68217A`)
+
+### Project Structure
+
+- **CodingWithCalvin.VSToolbox** - Main WinUI 3 application
+- **CodingWithCalvin.VSToolbox.Core** - Core library with models and services
+
+## Branch Naming Conventions
+
+Use the format: `type/short-description`
+
+Examples:
+- `feat/settings-dialog`
+- `fix/tray-icon-crash`
+- `docs/update-readme`
+
+## Commit Message Format
+
+We use [Conventional Commits](https://www.conventionalcommits.org/). Format:
+
+```
+type(scope): description
+```
+
+### Commit Types
+
+| Type | Description |
+|------|-------------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `test` | Adding or updating tests |
+| `chore` | Maintenance tasks |
+| `ci` | CI/CD changes |
+
+### Examples
+
+```
+feat(tray): add context menu for quick actions
+fix(detection): handle missing vswhere gracefully
+docs(readme): update installation instructions
+```
+
+## Submitting Pull Requests
+
+### Before You Start
+
+1. Check existing issues and PRs to avoid duplicate work
+2. For significant changes, open an issue first to discuss your approach
+3. Create a new branch from an updated `main` branch
+
+### Pull Request Process
+
+1. Update your fork:
+   ```bash
+   git checkout main
+   git pull upstream main
+   ```
+
+2. Create a feature branch:
+   ```bash
+   git checkout -b feat/your-feature-name
+   ```
+
+3. Make your changes and commit using conventional commit format
+
+4. Push to your fork:
+   ```bash
+   git push origin feat/your-feature-name
+   ```
+
+5. Open a pull request against `main`
+
+### Pull Request Guidelines
+
+- Use conventional commit format for the PR title (e.g., `feat(scope): description`)
+- Provide a clear description of the changes
+- Reference any related issues (e.g., "Closes #123")
+- Ensure the build passes
+- Keep PRs focused - one feature or fix per PR
+
+## Testing Requirements
+
+- Ensure the application builds without errors
+- Test your changes manually before submitting
+- Verify the application runs correctly on Windows 10/11
+
+## Getting Help
+
+- Open an issue for bugs or feature requests
+- Use discussions for questions and general help
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the same license as the project.


### PR DESCRIPTION
## Summary

- Add CONTRIBUTING.md with development environment setup, code style guidelines, branch naming conventions, conventional commit format, and PR process
- Add CODE_OF_CONDUCT.md based on Contributor Covenant 2.1 with "People FIRST" emphasis
- Add GitHub issue templates for bug reports and feature requests
- Add pull request template with description, type of change, and checklist

Closes #21
Closes #22
Closes #23