### PR TITLE
ci(workflow): remove social media posting from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,35 +97,3 @@ jobs:
           tag: ${{ github.ref_name }}
           prerelease: ${{ contains(github.ref_name, '-') }}
 
-  notify-bluesky:
-    needs: [release]
-    if: ${{ !contains(github.ref_name, '-') }}
-    uses: CodingWithCalvin/.github/.github/workflows/bluesky-post.yml@main
-    with:
-      post_text: |
-        🚀 Visual Studio Toolbox v${{ needs.release.outputs.version }} released!
-
-        Visual Studio Toolbox is a sleek system tray application for Windows that helps you manage all your Visual Studio installations in one place.
-
-        [Check out the release notes here!](https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }})
-    secrets:
-      BLUESKY_USERNAME: ${{ secrets.BLUESKY_USERNAME }}
-      BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
-
-  notify-x:
-    needs: [release]
-    if: ${{ !contains(github.ref_name, '-') }}
-    uses: CodingWithCalvin/.github/.github/workflows/x-post.yml@main
-    with:
-      post_text: |
-        🚀 Visual Studio Toolbox v${{ needs.release.outputs.version }} released!
-
-        Visual Studio Toolbox is a sleek system tray application for Windows that helps you manage all your Visual Studio installations in one place.
-
-        Check out the release notes here: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
-    secrets:
-      X_CONSUMER_KEY: ${{ secrets.X_CONSUMER_KEY }}
-      X_CONSUMER_KEY_SECRET: ${{ secrets.X_CONSUMER_KEY_SECRET }}
-      X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
-      X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
-


### PR DESCRIPTION
## Summary
- Remove BlueSky and X/Twitter posting jobs from the release workflow

## Test plan
- [ ] Verify release workflow still creates GitHub releases correctly